### PR TITLE
XACML 3.0 feature improvement

### DIFF
--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/BaseFunctionFactory.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/BaseFunctionFactory.java
@@ -35,11 +35,7 @@
 
 package org.wso2.balana.cond;
 
-import org.wso2.balana.ParsingException;
-import org.wso2.balana.UnknownIdentifierException;
-
 import java.net.URI;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -48,6 +44,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.w3c.dom.Node;
+import org.wso2.balana.ParsingException;
+import org.wso2.balana.UnknownIdentifierException;
 
 /**
  * This is a basic implementation of <code>FunctionFactory</code>. It implements the insertion and
@@ -68,7 +66,7 @@ import org.w3c.dom.Node;
 public class BaseFunctionFactory extends FunctionFactory {
 
     // the backing maps for the Function objects
-    private HashMap functionMap = null;
+    private HashMap functionMap = new HashMap();
 
     // the superset factory chained to this factory
     private FunctionFactory superset = null;
@@ -89,7 +87,6 @@ public class BaseFunctionFactory extends FunctionFactory {
      * @param superset the superset factory or null
      */
     public BaseFunctionFactory(FunctionFactory superset) {
-        functionMap = new HashMap();
 
         this.superset = superset;
     }

--- a/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/StringCreationFunction.java
+++ b/modules/balana-core/src/main/java/org/wso2/balana/cond/xacml3/StringCreationFunction.java
@@ -18,13 +18,31 @@
 
 package org.wso2.balana.cond.xacml3;
 
-import org.wso2.balana.attr.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.wso2.balana.attr.AnyURIAttribute;
+import org.wso2.balana.attr.AttributeValue;
+import org.wso2.balana.attr.BooleanAttribute;
+import org.wso2.balana.attr.DNSNameAttribute;
+import org.wso2.balana.attr.DateAttribute;
+import org.wso2.balana.attr.DateTimeAttribute;
+import org.wso2.balana.attr.DayTimeDurationAttribute;
+import org.wso2.balana.attr.DoubleAttribute;
+import org.wso2.balana.attr.IPAddressAttribute;
+import org.wso2.balana.attr.IntegerAttribute;
+import org.wso2.balana.attr.RFC822NameAttribute;
+import org.wso2.balana.attr.StringAttribute;
+import org.wso2.balana.attr.TimeAttribute;
+import org.wso2.balana.attr.X500NameAttribute;
+import org.wso2.balana.attr.YearMonthDurationAttribute;
 import org.wso2.balana.cond.Evaluatable;
 import org.wso2.balana.cond.EvaluationResult;
 import org.wso2.balana.cond.FunctionBase;
 import org.wso2.balana.ctx.EvaluationCtx;
-
-import java.util.*;
 
 /**
  * String creation function that creates String from other data types
@@ -37,64 +55,64 @@ public class StringCreationFunction extends FunctionBase {
     public static final String NAME_STRING_FROM_BOOLEAN = FUNCTION_NS_3 + "string-from-boolean";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-double function.
      */
     public static final String NAME_STRING_FROM_DOUBLE= FUNCTION_NS_3 + "string-from-double";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-time function.
      */
     public static final String NAME_STRING_FROM_TIME = FUNCTION_NS_3 + "string-from-time";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-date function.
      */
-    public static final String NAME_STRING_FROM_DATE_TIME = FUNCTION_NS_3 + "string-from-date";
+    public static final String NAME_STRING_FROM_DATE = FUNCTION_NS_3 + "string-from-date";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the dateTime-from-string function.
      */
-    public static final String NAME_STRING_FROM_DATE= FUNCTION_NS_3 + "dateTime-from-string";
+    public static final String NAME_STRING_FROM_DATE_TIME= FUNCTION_NS_3 + "string-from-dateTime";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-integer function.
      */
     public static final String NAME_STRING_FROM_INTEGER = FUNCTION_NS_3 + "string-from-integer";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-anyURI function.
      */
     public static final String NAME_STRING_FROM_URI = FUNCTION_NS_3 + "string-from-anyURI";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-dayTimeDuration function.
      */
     public static final String NAME_STRING_FROM_DAYTIME_DURATION = FUNCTION_NS_3 +
                                                                     "string-from-dayTimeDuration";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-yearMonthDuration function.
      */
     public static final String NAME_STRING_FROM_YEAR_MONTH_DURATION = FUNCTION_NS_3 +
                                                                     "string-from-yearMonthDuration";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-x500Name function.
      */
     public static final String NAME_STRING_FROM_X500NAME = FUNCTION_NS_3 + "string-from-x500Name";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-rfc822Name function.
      */
     public static final String NAME_STRING_FROM_RFC822NAME = FUNCTION_NS_3 + "string-from-rfc822Name";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-dnsName function.
      */
     public static final String NAME_STRING_FROM_DNS = FUNCTION_NS_3 + "string-from-dnsName";
 
     /**
-     *  Standard identifier for the String-from-boolean function.
+     *  Standard identifier for the string-from-ipAddress function.
      */
     public static final String NAME_STRING_FROM_IP_ADDRESS = FUNCTION_NS_3 + "string-from-ipAddress";
 


### PR DESCRIPTION
What does this PR do?
Corrects the StringCreationFunction to implement string-from-dateTime in order to facilitate XACML 3.0 conformance.

Who is reviewing it?

@stustison 

Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest)?

@stustison

How should this be tested?

N/A

Any background context you want to provide?

In an effort to fully support XACML 3.0 the current code base was reviewed for conformance.  All required functions will now be implemented.

What are the relevant tickets?

N/A
